### PR TITLE
Added additional location for Vagrant based on our local development env...

### DIFF
--- a/vv
+++ b/vv
@@ -358,6 +358,8 @@ get_vvv_path(){
 			path=$(pwd)
 		elif [ -e ~/Sites/Vagrantfile ] && [ -z $force_path ]; then
 			path=~/Sites
+		elif [ -e ~/Sites/Vagrant/Vagrantfile ] && [ -z $force_path ]; then
+			path=~/Sites/Vagrant
 		elif [ -e ~/vagrant/Vagrantfile ] && [ -z $force_path ]; then
 			path=~/vagrant
 		elif [ -e ~/vagrant-local/Vagrantfile ] && [ -z $force_path ]; then


### PR DESCRIPTION
We typically use ~/Sites/Vagrant for our local development since we have multiple sources sites are loaded into ~/Sites such as ~/Sites/Github, ~/Sites/Mercurial and ~/Sites/Local - this pull adds an additional location to check for the vagrantfile within ~/Sites.