### PR TITLE
vv-install, Breakline, verbose and others

### DIFF
--- a/vv-install
+++ b/vv-install
@@ -38,7 +38,7 @@ function main( $blueprint, $path = 'htdocs' ) {
 }
 
 function install ( $type, $object, $path ) {
-    echo "Installing $object...\n";
+    echo "  Installing $object...\n";
 	if ( strpos( $object, '.git' ) !== false ) {
 		exec( "mkdir -p $path/wp-content/{$type}s && cd $path/wp-content/{$type}s && git clone $object && cd -" );
 	} elseif ( strpos( $object, '.zip' ) !== false ) {
@@ -57,12 +57,12 @@ function add_option( $option ) {
 	$b = $object[1];
 	exec( "wp --allow-root option delete $a" );
 	exec( "wp --allow-root option add $a $b" );
-	echo "Insert settings $a...\n";
+	echo "  Insert settings $a...\n";
 }
 
 function add_define( $object, $path ) {
 	$object = explode( "::", $object );
-	echo "Insert constants $object[0]...\n";
+	echo "  Insert constants $object[0]...\n";
 	if(strtolower($object[1]) === 'true' || strtolower($object[1]) === 'false') {
     exec( '     echo "$(sed "34a\\
 define(\"'. $object[0] . '\",' . $object[1]  . ');

--- a/vv-install
+++ b/vv-install
@@ -63,7 +63,7 @@ function add_option( $option ) {
 function add_define( $object, $path ) {
 	$object = explode( "::", $object );
 	echo "  Insert constants $object[0]...\n";
-	if(strtolower($object[1]) === 'true' || strtolower($object[1]) === 'false') {
+	if(is_bool($object[1])) {
     exec( '     echo "$(sed "34a\\
 define(\"'. $object[0] . '\",' . $object[1]  . ');
 " ./' . $path . '/wp-config.php);" > ./' . $path . '/wp-config.php' );

--- a/vv-install
+++ b/vv-install
@@ -5,25 +5,25 @@ function main( $blueprint, $path = 'htdocs' ) {
 	$blueprints = json_decode( file_get_contents( "vv-blueprints.json") );
 
 	if ( ! empty( $blueprints->$blueprint->themes ) ) {
-		echo "Installing themes...";
+		echo "Installing themes...\n";
 		foreach( $blueprints->$blueprint->themes as $theme ) {
 			install( 'theme', $theme, $path );
 		}
 	}
 	if ( ! empty( $blueprints->$blueprint->plugins ) ) {
-		echo "Installing plugins...";
+		echo "Installing plugins...\n";
 		foreach( $blueprints->$blueprint->plugins as $plugin ) {
 			install( 'plugin', $plugin, $path );
 		}
 	}
 	if ( ! empty( $blueprints->$blueprint->mu_plugins ) ) {
-		echo "Installing mu-plugins...";
+		echo "Installing mu-plugins...\n";
 		foreach( $blueprints->$blueprint->mu_plugins as $mu_plugin ) {
 			install( 'mu-plugin', $mu_plugin, $path );
 		}
 	}
 	if ( ! empty( $blueprints->$blueprint->options ) ) {
-		echo "setting up options...";
+		echo "setting up options...\n";
 		foreach( $blueprints->$blueprint->options as $option ) {
 			add_option( $option );
 		}
@@ -34,7 +34,7 @@ function main( $blueprint, $path = 'htdocs' ) {
 	 		add_define( $define, $path );
 	 	}
 	}
-	echo "Blueprint set up.";
+	echo "Blueprint set up.\n";
 }
 
 function install ( $type, $object, $path ) {

--- a/vv-install
+++ b/vv-install
@@ -23,7 +23,7 @@ function main( $blueprint, $path = 'htdocs' ) {
 		}
 	}
 	if ( ! empty( $blueprints->$blueprint->options ) ) {
-		echo "setting up options...\n";
+		echo "Setting up options...\n";
 		foreach( $blueprints->$blueprint->options as $option ) {
 			add_option( $option );
 		}
@@ -38,6 +38,7 @@ function main( $blueprint, $path = 'htdocs' ) {
 }
 
 function install ( $type, $object, $path ) {
+    echo "Installing $object...\n";
 	if ( strpos( $object, '.git' ) !== false ) {
 		exec( "mkdir -p $path/wp-content/{$type}s && cd $path/wp-content/{$type}s && git clone $object && cd -" );
 	} elseif ( strpos( $object, '.zip' ) !== false ) {
@@ -56,13 +57,21 @@ function add_option( $option ) {
 	$b = $object[1];
 	exec( "wp --allow-root option delete $a" );
 	exec( "wp --allow-root option add $a $b" );
+	echo "Insert settings $a...\n";
 }
 
 function add_define( $object, $path ) {
 	$object = explode( "::", $object );
+	echo "Insert constants $object[0]...\n";
+	if(strtolower($object[1]) === 'true' || strtolower($object[1]) === 'false') {
+    exec( '     echo "$(sed "34a\\
+define(\"'. $object[0] . '\",' . $object[1]  . ');
+" ./' . $path . '/wp-config.php);" > ./' . $path . '/wp-config.php' );
+	} else {
 	exec( '		echo "$(sed "34a\\
 define(\"'. $object[0] . '\",\"' . $object[1]  . '\");
 " ./' . $path . '/wp-config.php);" > ./' . $path . '/wp-config.php' );
+    }
 }
 
 main( $argv[1], $argv[2] );


### PR DESCRIPTION
Little fix for improve the console output and the correct way for write boolean constants.

With `"SCRIPT_DEBUG::true"` in blueprint the boolean value are written with `"` and i get this errors:
```
[07-Mar-2015 11:39:58 UTC] PHP Warning:  include(/srv/www/demo/htdocs/wp-content/advanced-cache.php): failed to open stream: No such file or directory in /srv/www/demo/htdocs/wp-settings.php on line 65
[07-Mar-2015 11:39:58 UTC] PHP Warning:  include(): Failed opening '/srv/www/demo/htdocs/wp-content/advanced-cache.php' for inclusion (include_path='.:/usr/share/php:/usr/share/pear') in /srv/www/demo/htdocs/wp-settings.php on line 65
[07-Mar-2015 11:39:58 UTC] PHP Warning:  include(/srv/www/demo/htdocs/wp-content/advanced-cache.php): failed to open stream: No such file or directory in /srv/www/demo/htdocs/wp-settings.php on line 65
[07-Mar-2015 11:39:58 UTC] PHP Warning:  include(): Failed opening '/srv/www/demo/htdocs/wp-content/advanced-cache.php' for inclusion (include_path='.:/usr/share/php:/usr/share/pear') in /srv/www/demo/htdocs/wp-settings.php on line 65
```
So with this fix the boolean constants are written correctly because they are not string.