### PR TITLE
# make terminal go to newly created sites home dir

### DIFF
--- a/vv
+++ b/vv
@@ -704,6 +704,9 @@ function creation_success_message() {
 	echo "URL:       $domain"
 	echo "Username:  $username"
 	echo "Password:  $password"
+	
+	# make terminal go to newly created sites directory
+	cd $path/www/$site
 }
 
 function create_site() {


### PR DESCRIPTION
I'm not sure if this is the right way to implement it or if this makes sense in terms of placement within the script but I thought it might be handy to be able to have the script automatically fire into the newly created directory in case one wanted to do more terminal commands etc. Thoughts? 

# make terminal go to newly created sites directory
	cd $path/www/$site