### PR TITLE
Creates Roots.io Bedrock install

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Because vv knows where you VVV installation is, you can run it from anywhere. vv
 |`--name`, `-n`|Desired name for the site directory (e.g. mysite)|
 |`--domain, -d`|Domain of new site|
 |`--webroot`, `-wr`|Subdirectory used for web server root|
+|`--bedrock`, `-bed`|Creates Roots.io Bedrock install|
 |`--blueprint`, `-b`|Name of blueprint to use|
 |`--live-url`, `-u`|Live URL of site|
 |`--files`, `-f`|Do not provision Vagrant, just create the site directory and files|

--- a/vv
+++ b/vv
@@ -106,7 +106,7 @@ ${bold} SITE OPTIONS: ${normal}
     --password  		Admin password
     --email  			Admin email
     --git-repo, -gr  		Git repo to clone as wp-content
-    --bedrock, -b   		Creates Roots.io Bedrock install
+    --bedrock, -bed 		Creates Roots.io Bedrock install
     --blueprint, -b 		Name of blueprint to use
     --blank			Creates blank VVV site, with no WordPress
     --blank-with-db		Adds a blank VVV site, with a database
@@ -708,11 +708,6 @@ PHP"
 		blueprint_text="curl -o vv-install -s https://raw.githubusercontent.com/bradp/vv/vv-install/vv-install && php vv-install $blueprint $web_root && rm vv-blueprints.json"
 	fi
 
-	bedrock_text=''
-	if [[ $bedrock_init ]]; then
-		bedrock_text="echo \"Installing Bedrock stack using Composer\"\ncomposer create-project roots/bedrock htdocs"
-	fi
-
 	if [[ ! -z "$db_import" ]]; then
 		cp "$db_import" "$path"/"$sites_folder"/"$site"/"$site".sql
 	fi
@@ -741,7 +736,6 @@ PHP"
 				echo "	"
 				echo "	cd -"
 				echo "$blueprint_text"
-				echo "$bedrock_text"
 				echo "fi"
 			} >> vvv-init.sh
 		fi
@@ -766,6 +760,11 @@ PHP"
 			install_method="git clone --recursive https://github.com/markjaquith/WordPress-Skeleton.git . "
 			config="echo \"<?php define( 'DB_NAME', '$db_name' ); define( 'DB_USER', 'wp' ); define( 'DB_PASSWORD', 'wp' ); define( 'DB_HOST', 'localhost' );\" >> local-config.php"
 			core=""
+		fi
+		if [ "$bedrock_init" = "true" ]; then
+			install_method="composer create-project roots/bedrock htdocs"
+			config="printf \"DB_NAME=$db_name\nDB_USER=wp\nDB_PASSWORD=wp\nDB_HOST=localhost\n\nWP_ENV=development\nWP_HOME=http://$domain\nWP_SITEURL=http://$domain/wp\" >> htdocs/.env"
+			core="$core --path=\"htdocs/web/wp\""
 		fi
 		printf "\nCREATE DATABASE IF NOT EXISTS \`%s\`;\n"\
 "GRANT ALL PRIVILEGES ON \`%s\`.* TO 'wp'@'localhost' IDENTIFIED BY 'wp';\n" "$db_name" "$db_name" >> "$path"/database/init-custom.sql
@@ -1333,7 +1332,7 @@ check_args() {
 				;;
 			-bed|--bedrock)
 				bedrock_init="true"
-				no_wp="true"
+				web_root="htdocs/web"
 				no_wp_with_db="true"
 				shift
 				;;

--- a/vv
+++ b/vv
@@ -106,6 +106,7 @@ ${bold} SITE OPTIONS: ${normal}
     --password  		Admin password
     --email  			Admin email
     --git-repo, -gr  		Git repo to clone as wp-content
+    --bedrock, -b   		Creates Roots.io Bedrock install
     --blueprint, -b 		Name of blueprint to use
     --blank			Creates blank VVV site, with no WordPress
     --blank-with-db		Adds a blank VVV site, with a database
@@ -1322,6 +1323,10 @@ check_args() {
 				;;
 			--wpskeleton|--skel,-skel)
 				wpskeleton="true"
+				shift
+				;;
+			-bed|--bedrock)
+				echo "bedrock"
 				shift
 				;;
 			*)

--- a/vv
+++ b/vv
@@ -708,6 +708,11 @@ PHP"
 		blueprint_text="curl -o vv-install -s https://raw.githubusercontent.com/bradp/vv/vv-install/vv-install && php vv-install $blueprint $web_root && rm vv-blueprints.json"
 	fi
 
+	bedrock_text=''
+	if [[ $bedrock_init ]]; then
+		bedrock_text="echo \"Installing Bedrock stack using Composer\"\ncomposer create-project roots/bedrock htdocs"
+	fi
+
 	if [[ ! -z "$db_import" ]]; then
 		cp "$db_import" "$path"/"$sites_folder"/"$site"/"$site".sql
 	fi
@@ -736,6 +741,7 @@ PHP"
 				echo "	"
 				echo "	cd -"
 				echo "$blueprint_text"
+				echo "$bedrock_text"
 				echo "fi"
 			} >> vvv-init.sh
 		fi
@@ -1326,7 +1332,9 @@ check_args() {
 				shift
 				;;
 			-bed|--bedrock)
-				echo "bedrock"
+				bedrock_init="true"
+				no_wp="true"
+				no_wp_with_db="true"
 				shift
 				;;
 			*)


### PR DESCRIPTION
Adds a --bedrock, -bed flag to install Roots.io Bedrock app install.

Should be straight forward. Very similar to wordpress-skeleton. In fact, logic in the same place.

Should also be non-interfering, very clean insert. Lemme know if need changes. Cheers!