### PR TITLE
Check for local `.vv-config` file that overrides the one in `$HOME`.

### DIFF
--- a/vv
+++ b/vv
@@ -413,9 +413,10 @@ argument_expected() {
 
 check_for_config_file() {
 	hook "pre_vv_config_check"
-	test -f "$HOME"/.vv-config && got_config="true"
+	test -f "$HOME"/.vv-config && vv_config="${HOME}/.vv-config"
+	test -f ./.vv-config && vv_config="./.vv-config"
 
-	if [ ! -z $got_config ]; then
+	if [ ! -z $vv_config ]; then
 		load_config_values
 	else
 		if [[ ! $showing_help = "true" ]]; then
@@ -443,7 +444,7 @@ create_config_file() {
 }
 
 get_config_value() {
-	value=$(grep --color=never "$1" "$HOME"/.vv-config | sed 's/"//g' | sed "s/$1://g" | sed "s/,//g" )
+	value=$(grep --color=never "$1" "$vv_config" | sed 's/"//g' | sed "s/$1://g" | sed "s/,//g" )
 	echo "$value"
 }
 
@@ -1393,6 +1394,7 @@ output_debug_vv() {
 	echo ""
 	echo "vv: $(which vv)"
 	echo ""
+	echo "vv_config: $vv_config"
 	echo "vvv path: $path"
 	echo "home: $HOME"
 	echo ""


### PR DESCRIPTION
This allows the use of `vv` with multiple `VVV` installations on one machine, by providing a different `$path` for each.

Resolves #187