### PR TITLE
vv-config file never created causing repeated prompts for VVV directory path

### DIFF
--- a/vv
+++ b/vv
@@ -518,7 +518,7 @@ get_vvv_path(){
 			create_config_file
 		else
 			unset path
-		fi
+		
 
 		while [ -z "$path" ]; do
 			read -r -e -p "VVV install directory: " path
@@ -530,6 +530,8 @@ get_vvv_path(){
 			fi
 			path=$(eval echo "${path//>}")
 		done
+		create_config_file
+		fi
 	fi
 	path=${path%/}
 }


### PR DESCRIPTION
I received repeated prompts for  VVV directory path each time I ran vv , similar as described in https://github.com/bradp/vv/issues/179.

It appears as if the call to `create_config_file` was never done after the path is requested from the user. This patch fixes that.