### PR TITLE
bugfix - complains when no tput is installed.

### DIFF
--- a/vv
+++ b/vv
@@ -44,7 +44,7 @@ if [[ "$1" == "vv_internal_debug" ]]; then
 	shift
 fi
 
-if [[ ! -z $(which tput) ]]; then
+if [[ ! -z $(whichtput 2>/dev/null) ]]; then
 	normal=$(tput sgr0)
 	bold=$(tput bold)
 	red=$(tput setaf 1)
@@ -1385,7 +1385,7 @@ output_debug_vv() {
 	echo "vvv path: $path"
 	echo "home: $HOME"
 	echo ""
-	echo "tput: $(which tput)"
+	echo "tput: $(whichtput 2>/dev/null)"
 	echo "cat: $(which cat)"
 	echo "curl: $(which curl)"
 	echo "brew: $(which brew)"


### PR DESCRIPTION
I get the following when trying to run `vv` in a cygwin environment on Windows 7 (no `tput` installed) : 

`which: no tput in (/home/adruff/local/bin:/usr/sbin:/usr/local/bin:..... < dump of my entire path which is 10+ lines long > )`

This fix just diverts stderr to /dev/null to silence the complaint.