### PR TITLE
Remove temporary directory on update

### DIFF
--- a/vv
+++ b/vv
@@ -321,7 +321,7 @@ vv_bootstrap_update() {
 	tar -C "$HOME" -zxvf "$HOME/$github_version.tar.gz" 2>/dev/null
 	rm "$HOME/$github_version.tar.gz"
 	cat "$HOME/vv-$github_version/vv" > "$vv_install_location"
-	rm "$HOME/vv-$github_version"
+	rm -rf "$HOME/vv-$github_version"
 	success "vv has been updated to the latest version. Thanks!"
 	hook "post_vv_bootstrap_update"
 }


### PR DESCRIPTION
Currently there's an error like this: rm: cannot remove ‘/home/user/vv-1.9.3’: Is a directory

I'm just adding a recursive flag so it can delete the directory.