### PR TITLE
Use recursive flag for removing directories

### DIFF
--- a/vv
+++ b/vv
@@ -321,7 +321,7 @@ vv_bootstrap_update() {
 	tar -C "$HOME" -zxvf "$HOME/$github_version.tar.gz" 2>/dev/null
 	rm "$HOME/$github_version.tar.gz"
 	cat "$HOME/vv-$github_version/vv" > "$vv_install_location"
-	rm "$HOME/vv-$github_version"
+	rm -r "$HOME/vv-$github_version"
 	success "vv has been updated to the latest version. Thanks!"
 	hook "post_vv_bootstrap_update"
 }


### PR DESCRIPTION
When updating `vv` and it is not installed with `brew`, you need to use `rm -r` to remove the temporary directory.

As it was, it produced the following error:

```
rm: cannot remove ‘/home/scott/vv-1.9.3’: Is a directory
```