### PR TITLE
Yes should be default if Y is uppercase

### DIFF
--- a/vv
+++ b/vv
@@ -518,7 +518,7 @@ get_vvv_path(){
 			info "Automagically found $path"
 			prompt "Is this where VVV is installed? (Y/n)"
 			read -r path_confirmation
-			if [ "$path_confirmation" = 'Y' ]; then
+			if [ "$path_confirmation" != 'n' ]; then
 				create_config_file
 			else
 				unset path


### PR DESCRIPTION
Common practice for bash scripts is that the letter in uppercase is the default (i.e. the selected if you just press enter). 
I changed the check for path confirmation to make yes the default and to require an explicit `n` for no. As a minimum both `y` and `Y` should be accepted. 