### PR TITLE
Edit README.md to properly describe post_site_creation_finished hook variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,10 +316,12 @@ For example, saving this file as the name of any hook will output 'Hello' when t
 ```
 
 Another example would be running npm install inside of wp-content for all new sites.
-Make a file named post_site_creation_finished - this file gets 4 variables passed in, the hook name, the site name, the site domain, and the name of the site folder
+
+Make a file named post_site_creation_finished. This file gets 4 variables passed in: the hook name, the name of the site folder, the site domain, and the VVV path.
+
 ```bash
     #!/bin/bash
-    cd www/"$4"/htdocs/wp-content || exit
+    cd www/"$2"/htdocs/wp-content || exit
     npm install
 ```
 


### PR DESCRIPTION
Attempting to set up a `post_site_creation_finished` hook as per the [README](https://github.com/bradp/vv/blob/master/README.md#vv-hooks) resulted in an error.

**Steps to Reproduce**

1. Create a hook script at ``vv/post_site_creation_finished`, beginning with:

```
#!/bin/bash
cd www/"$4"/htdocs/wp-content || exit
```
2. Run `vv create` to set up a new site.

**Expected Result**

Hook executes.

**Actual Result**

The following error:

```
/Users/<myusername>/Sites/vv/post_site_creation_finished: line 2: cd: www//Users/<myusername>/Sites/htdocs/wp-content/mu-plugins: No such file or directory
```

**vv --debug-vv Results**

```
vv version 1.9.3

vv: /usr/local/bin/vv

vvv path: 	 /Users/<myusername>/Sites
home: /Users/<myusername>

tput: /usr/bin/tput
cat: /bin/cat
curl: /usr/bin/curl
brew: /usr/local/bin/brew
tar: /usr/bin/tar
find: /usr/bin/find
git: /usr/bin/git
sed: /usr/bin/sed
paste: /usr/bin/paste
vagrant: /usr/local/bin/vagrant
```