### PR TITLE
Add support for configuring a WP Multi-Network install from a blueprint file

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,52 @@ The above installs [BuddyPress](https://buddypress.org/) but activates it only f
 
 Be sure to run `vv` with the `--multisite subdomain` option when you use a blueprint like this.
 
+### Blueprints for Multi-Network configurations
+
+In addition to a [multisite configuration](#blueprints-for-multisite-configurations), VV recognizes blueprints that will configure a WP Multi-Network (a network of WP Multisite networks). VV's Multi-Network blueprints work just like Multisite blueprints, but have the following required additions:
+
+* A `BLUEPRINT_NAME::subnetwork_domains` key must be present listing the root domains for each network.
+* A `networks` object must be present, whose keys match the domains listed in the `BLUEPRINT_NAME::subnetwork_domains` member.
+
+For example, this Multi-Network configuration defines two WP Multisite subnetworks (for a total of three WP Multisites) in the blueprint called `multinet`.
+
+```json
+{
+  "multinet": {
+    "multinet::subdomains": "site2 site3",
+    "multinet::subnetwork_domains": "wpsubnet1.dev wpsubnet2.dev",
+    "networks": {
+      "wpsubnet1.dev": {
+        "path": "/",
+        "site_name": "WP Subnetwork Example 1"
+      },
+      "wpsubnet2.dev": {
+        "path": "/",
+        "site_name": "WP Subnetwork Example 2"
+      }
+    }
+  }
+}
+```
+
+Note that empty network objects are allowed (i.e., `path` and `site_name` are optional), but not recommended.
+
+To associate a given subsite with a network, you can either use the `network_id` key or a `network_domain` key in the subsite object. A `network_domain` is recommended. For example, this object will associate the `site2` subsite with the main network (because no `network_domain` or `network_id` key is defined), and the subsite with slug `site3` with the network created at the given domain:
+
+```json
+{
+  "site2": {
+  },
+  "site3": {
+    "network_domain": "wpsubnet1.dev"
+  }
+}
+```
+
+The above will ultimately place `site3` at the `site3.wpsubnet1.dev` URL while `site2` will be created as a subdomain of whatever domain you chose when you invoked `vv create`.
+
+It is not an error for a WP network to be defined with no sites of its own.
+
 ## Vagrant Proxy
 
 Because vv knows where you VVV installation is, you can run it from anywhere. vv will proxy any commands passed into `vv vagrant <command>` to your VVV location. So `vv vagrant halt` will halt your VVV vagrant, no matter where you run it.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@
   - [Flags](#flags)
 - [Blueprints](#blueprints)
   - [Blueprints for Multisite configurations](#blueprints-for-multisite-configurations)
+  - [Blueprints for Multi-Network configurations](#blueprints-for-multi-network-configurations)
 - [Vagrant Proxy](#vagrant-proxy)
 - [vv Options](#vv-options)
   - [Commands](#commands)

--- a/vv
+++ b/vv
@@ -1087,11 +1087,23 @@ PHP"
 	if [ ! -z "$blueprint" ] && [[ $ms_type == "subdomain" ]]; then
 		info "Adding subdomains from $blueprint to vvv-hosts file..."
 		local subdomains
+		local subnetwork_domains
 		subdomains=$(grep "$blueprint::subdomains" "$path"/vv-blueprints.json | sed -e 's/"//g' | cut -d ':' -f 4)
 		subdomains=${subdomains%,}
+		subnetwork_domains=$(grep "$blueprint::subnetwork_domains" "$path"/vv-blueprints.json | sed -e 's/"//g' | cut -d ':' -f 4)
+		subnetwork_domains=${subnetwork_domains%,}
 		for subdomain in $subdomains; do
 			printf "%s\n" "$subdomain.$domain" >> vvv-hosts
 		done
+		if [ ! -z "$subnetwork_domains" ]; then
+			info "Adding subnetwork domains and subdomains to vvv-hosts file..."
+			for subnetwork_domain in $subnetwork_domains; do
+				printf "%s\n" "$subnetwork_domain" >> vvv-hosts
+				for subdomain in $subdomains; do
+					printf "%s\n" "$subdomain.$subnetwork_domain" >> vvv-hosts
+				done
+			done
+		fi
 	fi
 	hook "post_write_vvv_hosts"
 	echo "Done"
@@ -1108,6 +1120,11 @@ PHP"
 	nginx_domain_text="$domain"
 	if [[ $multisite = 'y' ]] && [[ $ms_type = 'subdomain' ]]; then
 		nginx_domain_text="$domain *.$domain"
+		if [ ! -z "$subnetwork_domains" ]; then
+			for subnetwork_domain in $subnetwork_domains; do
+				nginx_domain_text="$nginx_domain_text $subnetwork_domain *.$subnetwork_domain"
+			done
+		fi
 	fi
 	xip_domain=" ~^${site// /-}\\\.\\\d+\\\.\\\d+\\\.\\\d+\\\.\\\d+\\\.xip\\\.io$"
 	nginx_domain_text="$nginx_domain_text""$xip_domain"


### PR DESCRIPTION
This documents the changes introduced by PR #266, as well as enhancing the `vv` script to support WP Multi-Network installation.

A WP Multi-Network is a single WordPress installation that supports multiple Multisite networks. It uses the WP Multi-Network plugin and automatically configures an arbitrary number of additional root domains in addition to the domain specified during invocation of `vv create`.