### PR TITLE
eval replaced with declare

### DIFF
--- a/vv
+++ b/vv
@@ -59,7 +59,7 @@ if [ -z "$HOME" ]; then
 else
 	home="$HOME"
 fi
-eval HOME="$home"
+declare HOME="$home"
 
 # If we have tput, let's set our colors
 if [[ ! -z $(which tput 2>/dev/null) ]]; then


### PR DESCRIPTION
Fixes the below error from occurring when the path contains a space.

Path: `C:\Users\USER NAME\`
Error: `line 62: NAME: command not found`