### PR TITLE
vv create: Add new site to vvv-config.yml to provision

### DIFF
--- a/vv
+++ b/vv
@@ -1131,6 +1131,12 @@ PHP"
 		mv tmp.conf "$site".conf
 	fi
 
+	# Add site to vvv-config.yml
+	# =============================================================================
+	cd "$path" || __vv__error "Could not change directory."
+	__vv__info "Adding $site to vvv-config.yml... "
+	echo -e "\n  $site:" >> vvv-config.yml
+
 	echo "Done"
 }
 


### PR DESCRIPTION
Fixes #324, issue provisioning new site with vv create. Appends sites to the new YAML config file that controls VVV, explained by @LoreleiAurora in Varying-Vagrant-Vagrants/VVV#980.