### PR TITLE
Fix for #144 – vagrant ssh not working

### DIFF
--- a/vv
+++ b/vv
@@ -1666,7 +1666,7 @@ __vv__check_args() {
 				__vv__argument_expected "$1" "$2"
 				__vv__get_vvv_path
 				cd "$path" || __vv__error "Could not change directory."
-				echo "$(vagrant "$2");"
+				exec vagrant "${@:2}"
 				exit
 				shift 2
 				;;


### PR DESCRIPTION
@bradp This should be a suitable fix for the issue discussed in #144.

I've replaced the use of `echo` with `exec`. So rather than 'proxying' the `vagrant` command to a non-interactive sub-shell and just returning the output, `exec` will replace the current interactive shell with the vagrant command.

Not only does this mean `vv vagrant ssh` will work as expected, but it also means that other niceties are retained, such as text colour and formatting.

Note also the use of `${@:2}` instead of `$2`, causing all parameters after 'vagrant' to be retained. This means more complicated commands can be proxied to vagrant, e.g. `vv vagrant ssh --help` will execute `vagrant ssh --help`.